### PR TITLE
feat(sdk): Enhance Ollama API client and add full `think` parameter s…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ lint: ## Lint code with black check and ruff
 # ==============================================================================
 
 .PHONY: test
-test: unit-test build-test db-test e2e-test## Run the full test suite
+test: unit-test sdk-test build-test db-test e2e-test ## Run the full test suite
 
 .PHONY: unit-test
 unit-test: ## Run the unit tests locally

--- a/sdk/olm_api_client/README.md
+++ b/sdk/olm_api_client/README.md
@@ -50,6 +50,7 @@ client = OllamaApiClient(api_url="http://localhost:8000")
 ### Usage
 
 Specify the model for each request. If `model` is `None`, it falls back to the `OLLAMA_MODEL` environment variable.
+Optionally, you can pass `think=True` (or `False`) to control thinking mode when supported by the server.
 
 #### Streaming (`gen_stream`)
 
@@ -62,7 +63,8 @@ client = OllamaApiClient(api_url="http://localhost:8000")
 async def stream_example():
     response_stream = client.gen_stream(
         prompt="Why is the sky blue?",
-        model="qwen3:0.6b"
+        model="qwen3:0.6b",
+        think=True,
     )
     async for chunk in response_stream:
         print(chunk, end="", flush=True)
@@ -81,7 +83,8 @@ client = OllamaApiClient(api_url="http://localhost:8000")
 async def batch_example():
     response = await client.gen_batch(
         prompt="Why is the sky blue?",
-        model="qwen3:0.6b"
+        model="qwen3:0.6b",
+        think=False,
     )
     print(response)
 

--- a/sdk/olm_api_client/client.py
+++ b/sdk/olm_api_client/client.py
@@ -14,10 +14,12 @@ class OllamaApiClient:
     """
 
     def __init__(self, api_url: str | None = None):
-        self.api_url = api_url or os.getenv("OLM_API_ENDPOINT")
+        self.api_url = (
+            api_url or os.getenv("OLM_API_ENDPOINT") or os.getenv("OLLAMA_API_ENDPOINT")
+        )
         if not self.api_url:
             raise ValueError(
-                "API URL must be provided either as parameter or OLM_API_ENDPOINT environment variable"
+                "API URL must be provided either as parameter or via OLM_API_ENDPOINT."
             )
         self.api_url = self.api_url.rstrip("/")
         self.generate_endpoint = f"{self.api_url}/api/v1/generate"
@@ -50,6 +52,8 @@ class OllamaApiClient:
 
                     async for line in response.aiter_lines():
                         if line.startswith("data: "):
+                            if line.strip() == "data: [DONE]":
+                                break
                             try:
                                 data = json.loads(line[6:])  # Remove "data: " prefix
                                 if "response" in data:

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx
 import pytest
@@ -162,7 +162,7 @@ class TestIntegrationWithMock:
         mock_response.aiter_lines.return_value = async_generator_mock(
             mock_response_data
         )
-        mock_response.raise_for_status = MagicMock()
+        mock_response.raise_for_status = Mock()
 
         # Create mock stream context
         mock_stream_context = AsyncMock()
@@ -179,7 +179,7 @@ class TestIntegrationWithMock:
         mock_async_client.__aexit__.return_value = None
 
         with patch("httpx.AsyncClient", return_value=mock_async_client):
-            result = client._stream_response("test prompt", "test-model")
+            result = client._stream_response("test prompt", "test-model", None)
             chunks = []
             async for chunk in result:
                 chunks.append(chunk)
@@ -194,7 +194,7 @@ class TestIntegrationWithMock:
         # Create mock response object
         mock_response = MagicMock()
         mock_response.json.return_value = {"response": "Complete response text"}
-        mock_response.raise_for_status = MagicMock()
+        mock_response.raise_for_status = Mock()
 
         # Create mock client
         mock_client = AsyncMock()
@@ -206,7 +206,9 @@ class TestIntegrationWithMock:
         mock_async_client.__aexit__.return_value = None
 
         with patch("httpx.AsyncClient", return_value=mock_async_client):
-            result = await client._non_stream_response("test prompt", "test-model")
+            result = await client._non_stream_response(
+                "test prompt", "test-model", None
+            )
 
             assert result == "Complete response text"
             mock_client.post.assert_called_once()
@@ -227,7 +229,7 @@ class TestIntegrationWithMock:
 
         with patch("httpx.AsyncClient", return_value=mock_async_client):
             with pytest.raises(httpx.RequestError):
-                result = client._stream_response("test prompt", "test-model")
+                result = client._stream_response("test prompt", "test-model", None)
                 async for _ in result:
                     pass
 
@@ -242,4 +244,4 @@ class TestIntegrationWithMock:
             mock_client.post.side_effect = httpx.RequestError("Connection failed")
 
             with pytest.raises(httpx.RequestError):
-                await client._non_stream_response("test prompt", "test-model")
+                await client._non_stream_response("test prompt", "test-model", None)

--- a/tests/sdk/test_protocol.py
+++ b/tests/sdk/test_protocol.py
@@ -1,4 +1,4 @@
-from typing import get_type_hints
+from typing import AsyncGenerator, get_type_hints
 from unittest.mock import AsyncMock
 
 import pytest
@@ -56,13 +56,15 @@ class TestOllamaClientProtocol:
 
         # Create a mock that follows the protocol
         class ProtocolCompliantMock:
-            def gen_stream(self, prompt: str, model: str | None = None):
+            def gen_stream(
+                self, prompt: str, model: str | None = None
+            ) -> AsyncGenerator[str, None]:
                 return self._async_gen()
 
             async def gen_batch(self, prompt: str, model: str | None = None):
                 return "batch response"
 
-            async def _async_gen(self):
+            async def _async_gen(self) -> AsyncGenerator[str, None]:
                 yield "chunk1"
                 yield "chunk2"
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -61,7 +61,7 @@ async def unit_test_client(monkeypatch) -> AsyncGenerator[AsyncClient, None]:
 
 
 @pytest.fixture
-def fast_mock_client():
+def fast_mock_client() -> MockOllamaApiClient:
     """
     Provides a fast MockOllamaApiClient with zero delay for unit testing.
     """


### PR DESCRIPTION
…upport

This commit introduces several enhancements and fixes to the Ollama API client SDK.

Key changes include:
- Added a `think: bool | None` parameter to `gen_stream` and `gen_batch` methods across the SDK, allowing users to control the thinking process during generation.
- Updated the `OllamaApiClient` to include the `think` parameter in API requests.
- Added backward compatibility for the `OLLAMA_API_ENDPOINT` environment variable.
- Improved the SSE stream handling in `OllamaApiClient` to correctly process the `[DONE]` message.

The `MockOllamaApiClient` has been refactored for better testability and realism:
- The constructor now validates the `token_delay` and stores the `api_url`.
- The tokenizer (`_tokenize_realistic`) now preserves whitespace to better mimic real API output.
- The streaming logic (`_stream_response`) has been simplified.

Testing and documentation have been updated to reflect these changes:
- The `Makefile`'s `test` target now includes `sdk-test`.
- Type hints have been added to `tests/unit/conftest.py` and `tests/sdk/test_protocol.py`.
- Tests in `tests/sdk/test_client.py` have been updated to be consistent with the new method signatures.
- The `README.md` has been updated to document the new `think` parameter and its usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - APIエンドポイント解決を拡張（api_url指定に加え、OLM_API_ENDPOINT/OLLAMA_API_ENDPOINTも自動検出）。
- バグ修正
  - ストリーミング終了信号「[DONE]」を正しく検出して停止。
  - モック出力で空白・改行の体裁を保持。
  - 負のトークン遅延値を拒否し、安定性向上。
- ドキュメント
  - 任意のthinkパラメータ（対応サーバーで有効）の使い方を追記。
- テスト/チョア
  - make testにSDK/DBテストを追加し網羅性向上。テスト群を更新・強化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->